### PR TITLE
Support for Retry strategy

### DIFF
--- a/src/main/java/io/appform/kaal/KaalDefaultTaskRetryStrategy.java
+++ b/src/main/java/io/appform/kaal/KaalDefaultTaskRetryStrategy.java
@@ -1,0 +1,18 @@
+package io.appform.kaal;
+
+/**
+ * This {@link KaalTaskRetryStrategy} always returns false. As in the task will be executed only once for every runId, even
+ * if it fails the execution
+ */
+public class KaalDefaultTaskRetryStrategy<T extends KaalTask<T, R>, R> implements KaalTaskRetryStrategy<T, R>{
+
+    /**
+     * Ensures task will only be executed once, even if it fails
+     * @param taskData Data for the recently completed run
+     * @return Always false
+     */
+    @Override
+    public boolean shouldRetry(KaalTaskData<T, R> taskData) {
+        return false;
+    }
+}

--- a/src/main/java/io/appform/kaal/KaalSchedulerBuilder.java
+++ b/src/main/java/io/appform/kaal/KaalSchedulerBuilder.java
@@ -32,6 +32,7 @@ public class KaalSchedulerBuilder <T extends KaalTask<T, R>, R> {
     private long pollingInterval = DEFAULT_CHECK_DELAY;
     private KaalTaskRunIdGenerator<T, R> taskIdGenerator;
     private KaalTaskStopStrategy<T,R> stopStrategy;
+    private KaalTaskRetryStrategy<T,R> retryStrategy;
     private ExecutorService executorService;
 
     /**
@@ -64,6 +65,11 @@ public class KaalSchedulerBuilder <T extends KaalTask<T, R>, R> {
         return this;
     }
 
+    public KaalSchedulerBuilder<T,R> withTaskRetryStrategy(final KaalTaskRetryStrategy<T,R> retryStrategy) {
+        this.retryStrategy = retryStrategy;
+        return this;
+    }
+
     /**
      * Executor service to be used to execute a task. If not provided an unbounded cached thread pool is used.
      * @param executorService Custom executor service.
@@ -82,6 +88,7 @@ public class KaalSchedulerBuilder <T extends KaalTask<T, R>, R> {
         return new KaalScheduler<>(pollingInterval <= 0 ? DEFAULT_CHECK_DELAY : pollingInterval,
                                    Objects.requireNonNullElseGet(taskIdGenerator, KaalRandomTaskRunIdGenerator::new),
                                    Objects.requireNonNullElseGet(stopStrategy, KaalDefaultTaskStopStrategy::new),
+                                   Objects.requireNonNullElseGet(retryStrategy, KaalDefaultTaskRetryStrategy::new),
                                    Objects.requireNonNullElseGet(executorService, Executors::newCachedThreadPool));
     }
 }

--- a/src/main/java/io/appform/kaal/KaalTaskRetryStrategy.java
+++ b/src/main/java/io/appform/kaal/KaalTaskRetryStrategy.java
@@ -1,7 +1,16 @@
 package io.appform.kaal;
 
+/**
+ * A strategy used by the {@link KaalScheduler} to determine if a retry run for the task needs to be scheduled or not
+ * in case the current run ends up with an exception
+ */
 public interface KaalTaskRetryStrategy<T extends KaalTask<T, R>, R> {
 
+    /**
+     * Determines if a retry run for this task is needed or not
+     * @param taskData Data for the recently completed run
+     * @return True if a retry run is needed, false otherwise
+     */
     boolean shouldRetry(final KaalTaskData<T, R> taskData);
 
 }

--- a/src/main/java/io/appform/kaal/KaalTaskRetryStrategy.java
+++ b/src/main/java/io/appform/kaal/KaalTaskRetryStrategy.java
@@ -1,0 +1,7 @@
+package io.appform.kaal;
+
+public interface KaalTaskRetryStrategy<T extends KaalTask<T, R>, R> {
+
+    boolean shouldRetry(final KaalTaskData<T, R> taskData);
+
+}


### PR DESCRIPTION


---



 **DeputyDev generated PR summary:** 



---



 **Size M:** This PR changes include 91 lines and should take approximately 30-60 minutes to review



---

The pull request introduces a "Retry strategy" feature into the Kaal scheduling system. Here's a breakdown of the changes:

1. **New Interface: `KaalTaskRetryStrategy`**:
   - A new interface `KaalTaskRetryStrategy` is added, which defines a method `shouldRetry` to determine if a task should be retried after a failure.

2. **Default Implementation: `KaalDefaultTaskRetryStrategy`**:
   - A default implementation `KaalDefaultTaskRetryStrategy` is created which always returns `false`, meaning tasks will not be retried after failure.

3. **Integration with `KaalScheduler`**:
   - `KaalScheduler` is updated to include a `retryStrategy` field.
   - During task completion, the scheduler checks the `retryStrategy` to decide whether to retry a failed task.

4. **Builder Pattern Update: `KaalSchedulerBuilder`**:
   - The builder pattern for `KaalScheduler` is updated to allow setting a custom `retryStrategy`.
   - If no strategy is provided, the default strategy (`KaalDefaultTaskRetryStrategy`) is used.

5. **Test Enhancements**:
   - A new test `testSchedulerCustomRetryStrategy` is added to verify the retry logic. This test ensures that tasks are retried up to a specified number of times.

The PR essentially adds a mechanism to control task retry behavior, allowing developers to define custom retry logic or use the default strategy which does not retry tasks.

Here is an example of how the new retry strategy can be implemented:
```java
public class CustomRetryStrategy<T extends KaalTask<T, R>, R> implements KaalTaskRetryStrategy<T, R> {
    @Override
    public boolean shouldRetry(KaalTaskData<T, R> taskData) {
        // Custom logic to decide if a task should be retried
        return taskData.getException() != null && taskData.getRetryCount() < 3;
    }
}
```

This PR provides a flexible way to manage task execution failures, enhancing the robustness of task scheduling and execution.

---

DeputyDev generated PR summary until f684cdb3cd6a1c9d9f908521994d17fb5c849aa6